### PR TITLE
Add support for higher dependencies versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-oauth2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AngularJS OAuth2",
   "main": "./dist/angular-oauth2.js",
   "authors": [
@@ -23,8 +23,8 @@
     "test"
   ],
   "dependencies": {
-    "angular": "1.3.9",
-    "angular-cookie": "4.0.6",
-    "query-string": "1.0.0"
+    "angular": "^1.3.9",
+    "angular-cookie": "^4.0.6",
+    "query-string": "^1.0.0"
   }
 }

--- a/dist/angular-oauth2.js
+++ b/dist/angular-oauth2.js
@@ -1,6 +1,6 @@
 /**
  * angular-oauth2 - Angular OAuth2
- * @version v1.0.1
+ * @version v1.0.2
  * @link https://github.com/seegno/angular-oauth2
  * @license MIT
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-oauth2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Angular OAuth2",
   "main": "./dist/angular-oauth2.js",
   "scripts": {


### PR DESCRIPTION
Previously, the dependencies versions were locked to a single version. This commit adds caret operator in compliance with semver.