### PR TITLE
Update `oauthInterceptor` responseError handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ angular.module('myApp', ['angular-oauth2'])
 
 ```js
 angular.module('myApp', ['angular-oauth2'])
-  .run(['$rootScope', '$window', function($rootScope, $window) {
+  .run(['$rootScope', '$window', function($rootScope, $window, OAuth) {
     $rootScope.$on('oauth:error', function(event, rejection) {
       // Ignore `invalid_grant` error - should be catched on `LoginController`.
       if ('invalid_grant' === rejection.data.error) {
         return;
+      }
+
+      // Refresh token when a `invalid_token` error occurs.
+      if ('invalid_token' === rejection.data.error) {
+        return OAuth.getRefreshToken();
       }
 
       // Redirect to `/login` with the `error_reason`.

--- a/src/interceptors/oauth-interceptor.js
+++ b/src/interceptors/oauth-interceptor.js
@@ -17,13 +17,17 @@ function oauthInterceptor($q, $rootScope, OAuthToken) {
       return config;
     },
     responseError: function(rejection) {
-      // Catch `oauth` errors and ensure that the `token` is removed.
-      if (400 === rejection.status && rejection.data && 'invalid_request' === rejection.data.error ||
-        400 === rejection.status && 'invalid_grant' === rejection.data.error ||
-        401 === rejection.status && rejection.data && 'invalid_token' === rejection.data.error
+      // Catch `invalid_request` and `invalid_grant` errors and ensure that the `token` is removed.
+      if (400 === rejection.status && rejection.data &&
+        ('invalid_request' === rejection.data.error || 'invalid_grant' === rejection.data.error)
       ) {
         OAuthToken.removeToken();
 
+        $rootScope.$emit('oauth:error', rejection);
+      }
+
+      // Catch `invalid_token` error. Token isn't removed here so it can be refreshed.
+      if (401 === rejection.status && rejection.data && 'invalid_token' === rejection.data.error) {
         $rootScope.$emit('oauth:error', rejection);
       }
 

--- a/test/unit/interceptors/oauth-interceptor.spec.js
+++ b/test/unit/interceptors/oauth-interceptor.spec.js
@@ -95,19 +95,6 @@ describe('oauthInterceptor', function() {
     $rootScope.$emit.restore();
   }));
 
-  it('should remove `token` if an `invalid_token` error occurs', inject(function($http, $httpBackend, OAuthToken) {
-    sinon.spy(OAuthToken, 'removeToken');
-
-    $httpBackend.expectGET('https://website.com').respond(401, { error: 'invalid_token' });
-
-    $http.get('https://website.com');
-
-    $httpBackend.flush();
-
-    OAuthToken.removeToken.callCount.should.equal(1);
-    OAuthToken.removeToken.restore();
-  }));
-
   it('should emit `oauth:error` event if an `invalid_token` error occurs', inject(function($http, $httpBackend, $rootScope) {
     sinon.spy($rootScope, '$emit');
 


### PR DESCRIPTION
The `token` isn't being removed anymore when an `invalid_token` error occurs so it can be refreshed later on `oauth:error` listener.