### PR TITLE
Add options to `ipCookie.remove()` on OAuthToken

### DIFF
--- a/src/providers/oauth-token-provider.js
+++ b/src/providers/oauth-token-provider.js
@@ -101,7 +101,7 @@ function OAuthTokenProvider() {
        */
 
       removeToken() {
-        return ipCookie.remove(config.name);
+        return ipCookie.remove(config.name, config.options);
       }
     }
 


### PR DESCRIPTION
`ipCookie.remove` accepts 2 arguments: `key` and `options`.
In this PR we're adding the second argument that can already be configured in `OAuthTokenProvider`.

Fixes #9.