### PR TITLE
Add `client_id` and `client_secret` on revoke_token

### DIFF
--- a/src/providers/oauth-provider.js
+++ b/src/providers/oauth-provider.js
@@ -181,9 +181,16 @@ function OAuthProvider() {
        */
 
       revokeToken() {
-        var data = queryString.stringify({
+        var data = {
+          client_id: config.clientId,
           token: OAuthToken.getRefreshToken() ? OAuthToken.getRefreshToken() : OAuthToken.getAccessToken()
-        });
+        };
+
+        if (null !== config.clientSecret) {
+          data.client_secret = config.clientSecret;
+        }
+
+        data = queryString.stringify(data);
 
         var options = {
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' }

--- a/test/unit/providers/oauth-provider.spec.js
+++ b/test/unit/providers/oauth-provider.spec.js
@@ -363,6 +363,8 @@ describe('OAuthProvider', function() {
         queryString.stringify.callCount.should.equal(1);
         queryString.stringify.firstCall.args.should.have.lengthOf(1);
         queryString.stringify.firstCall.args[0].should.eql({
+          client_id: defaults.clientId,
+          client_secret: defaults.clientSecret,
           token: 'bar'
         });
         queryString.stringify.restore();
@@ -378,14 +380,18 @@ describe('OAuthProvider', function() {
         queryString.stringify.callCount.should.equal(1);
         queryString.stringify.firstCall.args.should.have.lengthOf(1);
         queryString.stringify.firstCall.args[0].should.eql({
-          token: 'foo'
+          client_id: defaults.clientId,
+          token: 'foo',
+          client_secret: defaults.clientSecret
         });
         queryString.stringify.restore();
       }));
 
       it('should return an error if `token` is missing', inject(function($httpBackend, OAuth) {
         var data = queryString.stringify({
-          token: undefined
+          client_id: defaults.clientId,
+          token: undefined,
+          client_secret: defaults.clientSecret
         });
 
         $httpBackend.expectPOST(defaults.baseUrl + defaults.revokePath, data)
@@ -407,7 +413,9 @@ describe('OAuthProvider', function() {
         OAuthToken.setToken({ token_type: 'bearer', access_token: 'foo', expires_in: 3600, refresh_token: 'bar' });
 
         var data = queryString.stringify({
-          token: 'bar'
+          client_id: defaults.clientId,
+          token: 'bar',
+          client_secret: defaults.clientSecret
         });
 
         $httpBackend.expectPOST(defaults.baseUrl + defaults.revokePath, data)


### PR DESCRIPTION
Adapted from [Django OAuth Tookit - Part 4 - Revoking an OAuth2 Token](http://django-oauth-toolkit.readthedocs.org/en/latest/tutorial/tutorial_04.html#setup-a-request)

Depending on the client type you’re using, the token revocation request you may submit to the authentication server may vary. A Public client, for example, will not have access to your Client Secret. A revoke request from a public client would omit that secret, but requires `client_id`. If your application type is Confidential , it requires the `client_secret`, so you will have to add it as one of the parameters.
