### PR TITLE
Update oauth config

### DIFF
--- a/src/providers/oauth-provider.js
+++ b/src/providers/oauth-provider.js
@@ -122,7 +122,7 @@ function OAuthProvider() {
 
         data = queryString.stringify(data);
 
-        options = angular.extend({
+        options = angular.merge({
           headers: {
             'Authorization': undefined,
             'Content-Type': 'application/x-www-form-urlencoded'


### PR DESCRIPTION
- To allow deep copy between configuration objects, it should use
  `merge` instead of `extend`.